### PR TITLE
BondingCurve Library Cleanup

### DIFF
--- a/project/contracts/BondingCurve.sol
+++ b/project/contracts/BondingCurve.sol
@@ -18,9 +18,7 @@ library BondingCurve {
       * @return supply * ((1 + amount / balance) ^ (weight / MAX_WEIGHT) - 1)
     */
     function buy(uint256 supply, uint256 balance, uint256 weight, uint256 amount) internal pure returns (uint256) { unchecked {
-        require(supply > 0, "invalid supply");
-        require(balance > 0, "invalid balance");
-        require(weight > 0, "invalid weight");
+        require(supply > 0 && balance > 0 && weight > 0, "invalid input");
         require(weight <= MAX_WEIGHT, "weight out of bound");
 
         if (weight == MAX_WEIGHT)
@@ -41,9 +39,7 @@ library BondingCurve {
       * @return balance * (1 - (1 - amount / supply) ^ (MAX_WEIGHT / weight))
     */
     function sell(uint256 supply, uint256 balance, uint256 weight, uint256 amount) internal pure returns (uint256) { unchecked {
-        require(supply > 0, "invalid supply");
-        require(balance > 0, "invalid balance");
-        require(weight > 0, "invalid weight");
+        require(supply > 0 && balance > 0 && weight > 0, "invalid input");
         require(weight <= MAX_WEIGHT, "weight out of bound");
         require(amount <= supply, "amount larger than supply");
 
@@ -69,12 +65,8 @@ library BondingCurve {
       * @return balance2 * (1 - (balance1 / (balance1 + amount)) ^ (weight1 / weight2))
     */
     function convert(uint256 balance1, uint256 weight1, uint256 balance2, uint256 weight2, uint256 amount) internal pure returns (uint256) { unchecked {
-        require(balance1 > 0, "invalid source balance");
-        require(balance2 > 0, "invalid target balance");
-        require(weight1 > 0, "invalid source weight");
-        require(weight2 > 0, "invalid target weight");
-        require(weight1 <= MAX_WEIGHT, "source weight out of bound");
-        require(weight2 <= MAX_WEIGHT, "target weight out of bound");
+        require(balance1 > 0 && balance2 > 0 && weight1 > 0 && weight2 > 0, "invalid input");
+        require(weight1 <= MAX_WEIGHT && weight2 <= MAX_WEIGHT, "weights out of bound");
 
         if (weight1 == weight2)
             return IntegralMath.mulDivF(balance2, amount, safeAdd(balance1, amount));
@@ -94,9 +86,7 @@ library BondingCurve {
       * @return supply * ((amount / balance + 1) ^ (weights / MAX_WEIGHT) - 1)
     */
     function deposit(uint256 supply, uint256 balance, uint256 weights, uint256 amount) internal pure returns (uint256) { unchecked {
-        require(supply > 0, "invalid supply");
-        require(balance > 0, "invalid balance");
-        require(weights > 0, "invalid weights");
+        require(supply > 0 && balance > 0 && weights > 0, "invalid input");
         require(weights <= MAX_WEIGHT * 2, "weights out of bound");
 
         if (weights == MAX_WEIGHT)
@@ -117,9 +107,7 @@ library BondingCurve {
       * @return balance * (1 - ((supply - amount) / supply) ^ (MAX_WEIGHT / weights))
     */
     function withdraw(uint256 supply, uint256 balance, uint256 weights, uint256 amount) internal pure returns (uint256) { unchecked {
-        require(supply > 0, "invalid supply");
-        require(balance > 0, "invalid balance");
-        require(weights > 0, "invalid weights");
+        require(supply > 0 && balance > 0 && weights > 0, "invalid input");
         require(weights <= MAX_WEIGHT * 2, "weights out of bound");
         require(amount <= supply, "amount larger than supply");
 
@@ -144,9 +132,7 @@ library BondingCurve {
       * @return balance * (((supply + amount) / supply) ^ (MAX_WEIGHT / weights) - 1)
     */
     function invest(uint256 supply, uint256 balance, uint256 weights, uint256 amount) internal pure returns (uint256) { unchecked {
-        require(supply > 0, "invalid supply");
-        require(balance > 0, "invalid balance");
-        require(weights > 0, "invalid weights");
+        require(supply > 0 && balance > 0 && weights > 0, "invalid input");
         require(weights <= MAX_WEIGHT * 2, "weights out of bound");
 
         if (weights == MAX_WEIGHT)

--- a/project/contracts/BondingCurve.sol
+++ b/project/contracts/BondingCurve.sol
@@ -5,7 +5,6 @@ import "./AnalyticMath.sol";
 import "./IntegralMath.sol";
 
 library BondingCurve {
-    uint256 internal constant MIN_WEIGHT = 1;
     uint256 internal constant MAX_WEIGHT = 1000000;
 
     /**

--- a/project/contracts/BondingCurve.sol
+++ b/project/contracts/BondingCurve.sol
@@ -21,10 +21,8 @@ library BondingCurve {
     function buy(uint256 supply, uint256 balance, uint256 weight, uint256 amount) internal pure returns (uint256) { unchecked {
         require(supply > 0, "invalid supply");
         require(balance > 0, "invalid balance");
-        require(MIN_WEIGHT <= weight && weight <= MAX_WEIGHT, "invalid weight");
-
-        if (amount == 0)
-            return 0;
+        require(weight > 0, "invalid weight");
+        require(weight <= MAX_WEIGHT, "weight out of bound");
 
         if (weight == MAX_WEIGHT)
             return IntegralMath.mulDivF(amount, supply, balance);
@@ -46,11 +44,9 @@ library BondingCurve {
     function sell(uint256 supply, uint256 balance, uint256 weight, uint256 amount) internal pure returns (uint256) { unchecked {
         require(supply > 0, "invalid supply");
         require(balance > 0, "invalid balance");
-        require(MIN_WEIGHT <= weight && weight <= MAX_WEIGHT, "invalid weight");
+        require(weight > 0, "invalid weight");
+        require(weight <= MAX_WEIGHT, "weight out of bound");
         require(amount <= supply, "amount larger than supply");
-
-        if (amount == 0)
-            return 0;
 
         if (amount == supply)
             return balance;
@@ -74,10 +70,12 @@ library BondingCurve {
       * @return balance2 * (1 - (balance1 / (balance1 + amount)) ^ (weight1 / weight2))
     */
     function convert(uint256 balance1, uint256 weight1, uint256 balance2, uint256 weight2, uint256 amount) internal pure returns (uint256) { unchecked {
-        require(0 < balance1, "invalid source balance");
-        require(0 < balance2, "invalid target balance");
-        require(MIN_WEIGHT <= weight1 && weight1 <= MAX_WEIGHT, "invalid source weight");
-        require(MIN_WEIGHT <= weight2 && weight2 <= MAX_WEIGHT, "invalid target weight");
+        require(balance1 > 0, "invalid source balance");
+        require(balance2 > 0, "invalid target balance");
+        require(weight1 > 0, "invalid source weight");
+        require(weight2 > 0, "invalid target weight");
+        require(weight1 <= MAX_WEIGHT, "source weight out of bound");
+        require(weight2 <= MAX_WEIGHT, "target weight out of bound");
 
         if (weight1 == weight2)
             return IntegralMath.mulDivF(balance2, amount, safeAdd(balance1, amount));
@@ -99,10 +97,8 @@ library BondingCurve {
     function deposit(uint256 supply, uint256 balance, uint256 weights, uint256 amount) internal pure returns (uint256) { unchecked {
         require(supply > 0, "invalid supply");
         require(balance > 0, "invalid balance");
-        require(MIN_WEIGHT * 2 <= weights && weights <= MAX_WEIGHT * 2, "invalid weights");
-
-        if (amount == 0)
-            return 0;
+        require(weights > 0, "invalid weights");
+        require(weights <= MAX_WEIGHT * 2, "weights out of bound");
 
         if (weights == MAX_WEIGHT)
             return IntegralMath.mulDivF(amount, supply, balance);
@@ -124,11 +120,9 @@ library BondingCurve {
     function withdraw(uint256 supply, uint256 balance, uint256 weights, uint256 amount) internal pure returns (uint256) { unchecked {
         require(supply > 0, "invalid supply");
         require(balance > 0, "invalid balance");
-        require(MIN_WEIGHT * 2 <= weights && weights <= MAX_WEIGHT * 2, "invalid weights");
+        require(weights > 0, "invalid weights");
+        require(weights <= MAX_WEIGHT * 2, "weights out of bound");
         require(amount <= supply, "amount larger than supply");
-
-        if (amount == 0)
-            return 0;
 
         if (amount == supply)
             return balance;
@@ -153,10 +147,8 @@ library BondingCurve {
     function invest(uint256 supply, uint256 balance, uint256 weights, uint256 amount) internal pure returns (uint256) { unchecked {
         require(supply > 0, "invalid supply");
         require(balance > 0, "invalid balance");
-        require(MIN_WEIGHT * 2 <= weights && weights <= MAX_WEIGHT * 2, "invalid weights");
-
-        if (amount == 0)
-            return 0;
+        require(weights > 0, "invalid weights");
+        require(weights <= MAX_WEIGHT * 2, "weights out of bound");
 
         if (weights == MAX_WEIGHT)
             return IntegralMath.mulDivC(amount, balance, supply);

--- a/project/emulation/FixedPoint/BondingCurve.py
+++ b/project/emulation/FixedPoint/BondingCurve.py
@@ -19,10 +19,8 @@ MAX_WEIGHT = 1000000;
 def buy(supply, balance, weight, amount):
     require(supply > 0, "invalid supply");
     require(balance > 0, "invalid balance");
-    require(MIN_WEIGHT <= weight and weight <= MAX_WEIGHT, "invalid weight");
-
-    if (amount == 0):
-        return 0;
+    require(weight > 0, "invalid weight");
+    require(weight <= MAX_WEIGHT, "weight out of bound");
 
     if (weight == MAX_WEIGHT):
         return IntegralMath.mulDivF(amount, supply, balance);
@@ -43,11 +41,9 @@ def buy(supply, balance, weight, amount):
 def sell(supply, balance, weight, amount):
     require(supply > 0, "invalid supply");
     require(balance > 0, "invalid balance");
-    require(MIN_WEIGHT <= weight and weight <= MAX_WEIGHT, "invalid weight");
+    require(weight > 0, "invalid weight");
+    require(weight <= MAX_WEIGHT, "weight out of bound");
     require(amount <= supply, "amount larger than supply");
-
-    if (amount == 0):
-        return 0;
 
     if (amount == supply):
         return balance;
@@ -70,10 +66,12 @@ def sell(supply, balance, weight, amount):
     @return balance2 * (1 - (balance1 / (balance1 + amount)) ^ (weight1 / weight2))
 '''
 def convert(balance1, weight1, balance2, weight2, amount):
-    require(0 < balance1, "invalid source balance");
-    require(0 < balance2, "invalid target balance");
-    require(MIN_WEIGHT <= weight1 and weight1 <= MAX_WEIGHT, "invalid source weight");
-    require(MIN_WEIGHT <= weight2 and weight2 <= MAX_WEIGHT, "invalid target weight");
+    require(balance1 > 0, "invalid source balance");
+    require(balance2 > 0, "invalid target balance");
+    require(weight1 > 0, "invalid source weight");
+    require(weight2 > 0, "invalid target weight");
+    require(weight1 <= MAX_WEIGHT, "source weight out of bound");
+    require(weight2 <= MAX_WEIGHT, "target weight out of bound");
 
     if (weight1 == weight2):
         return IntegralMath.mulDivF(balance2, amount, safeAdd(balance1, amount));
@@ -94,10 +92,8 @@ def convert(balance1, weight1, balance2, weight2, amount):
 def deposit(supply, balance, weights, amount):
     require(supply > 0, "invalid supply");
     require(balance > 0, "invalid balance");
-    require(MIN_WEIGHT * 2 <= weights and weights <= MAX_WEIGHT * 2, "invalid weights");
-
-    if (amount == 0):
-        return 0;
+    require(weights > 0, "invalid weights");
+    require(weights <= MAX_WEIGHT * 2, "weights out of bound");
 
     if (weights == MAX_WEIGHT):
         return IntegralMath.mulDivF(amount, supply, balance);
@@ -118,11 +114,9 @@ def deposit(supply, balance, weights, amount):
 def withdraw(supply, balance, weights, amount):
     require(supply > 0, "invalid supply");
     require(balance > 0, "invalid balance");
-    require(MIN_WEIGHT * 2 <= weights and weights <= MAX_WEIGHT * 2, "invalid weights");
+    require(weights > 0, "invalid weights");
+    require(weights <= MAX_WEIGHT * 2, "weights out of bound");
     require(amount <= supply, "amount larger than supply");
-
-    if (amount == 0):
-        return 0;
 
     if (amount == supply):
         return balance;
@@ -146,10 +140,8 @@ def withdraw(supply, balance, weights, amount):
 def invest(supply, balance, weights, amount):
     require(supply > 0, "invalid supply");
     require(balance > 0, "invalid balance");
-    require(MIN_WEIGHT * 2 <= weights and weights <= MAX_WEIGHT * 2, "invalid weights");
-
-    if (amount == 0):
-        return 0;
+    require(weights > 0, "invalid weights");
+    require(weights <= MAX_WEIGHT * 2, "weights out of bound");
 
     if (weights == MAX_WEIGHT):
         return IntegralMath.mulDivC(amount, balance, supply);

--- a/project/emulation/FixedPoint/BondingCurve.py
+++ b/project/emulation/FixedPoint/BondingCurve.py
@@ -16,9 +16,7 @@ MAX_WEIGHT = 1000000;
     @return supply * ((1 + amount / balance) ^ (weight / MAX_WEIGHT) - 1)
 '''
 def buy(supply, balance, weight, amount):
-    require(supply > 0, "invalid supply");
-    require(balance > 0, "invalid balance");
-    require(weight > 0, "invalid weight");
+    require(supply > 0 and balance > 0 and weight > 0, "invalid input");
     require(weight <= MAX_WEIGHT, "weight out of bound");
 
     if (weight == MAX_WEIGHT):
@@ -38,9 +36,7 @@ def buy(supply, balance, weight, amount):
     @return balance * (1 - (1 - amount / supply) ^ (MAX_WEIGHT / weight))
 '''
 def sell(supply, balance, weight, amount):
-    require(supply > 0, "invalid supply");
-    require(balance > 0, "invalid balance");
-    require(weight > 0, "invalid weight");
+    require(supply > 0 and balance > 0 and weight > 0, "invalid input");
     require(weight <= MAX_WEIGHT, "weight out of bound");
     require(amount <= supply, "amount larger than supply");
 
@@ -65,12 +61,8 @@ def sell(supply, balance, weight, amount):
     @return balance2 * (1 - (balance1 / (balance1 + amount)) ^ (weight1 / weight2))
 '''
 def convert(balance1, weight1, balance2, weight2, amount):
-    require(balance1 > 0, "invalid source balance");
-    require(balance2 > 0, "invalid target balance");
-    require(weight1 > 0, "invalid source weight");
-    require(weight2 > 0, "invalid target weight");
-    require(weight1 <= MAX_WEIGHT, "source weight out of bound");
-    require(weight2 <= MAX_WEIGHT, "target weight out of bound");
+    require(balance1 > 0 and balance2 > 0 and weight1 > 0 and weight2 > 0, "invalid input");
+    require(weight1 <= MAX_WEIGHT and weight2 <= MAX_WEIGHT, "weights out of bound");
 
     if (weight1 == weight2):
         return IntegralMath.mulDivF(balance2, amount, safeAdd(balance1, amount));
@@ -89,9 +81,7 @@ def convert(balance1, weight1, balance2, weight2, amount):
     @return supply * ((amount / balance + 1) ^ (weights / MAX_WEIGHT) - 1)
 '''
 def deposit(supply, balance, weights, amount):
-    require(supply > 0, "invalid supply");
-    require(balance > 0, "invalid balance");
-    require(weights > 0, "invalid weights");
+    require(supply > 0 and balance > 0 and weights > 0, "invalid input");
     require(weights <= MAX_WEIGHT * 2, "weights out of bound");
 
     if (weights == MAX_WEIGHT):
@@ -111,9 +101,7 @@ def deposit(supply, balance, weights, amount):
     @return balance * (1 - ((supply - amount) / supply) ^ (MAX_WEIGHT / weights))
 '''
 def withdraw(supply, balance, weights, amount):
-    require(supply > 0, "invalid supply");
-    require(balance > 0, "invalid balance");
-    require(weights > 0, "invalid weights");
+    require(supply > 0 and balance > 0 and weights > 0, "invalid input");
     require(weights <= MAX_WEIGHT * 2, "weights out of bound");
     require(amount <= supply, "amount larger than supply");
 
@@ -137,9 +125,7 @@ def withdraw(supply, balance, weights, amount):
     @return balance * (((supply + amount) / supply) ^ (MAX_WEIGHT / weights) - 1)
 '''
 def invest(supply, balance, weights, amount):
-    require(supply > 0, "invalid supply");
-    require(balance > 0, "invalid balance");
-    require(weights > 0, "invalid weights");
+    require(supply > 0 and balance > 0 and weights > 0, "invalid input");
     require(weights <= MAX_WEIGHT * 2, "weights out of bound");
 
     if (weights == MAX_WEIGHT):

--- a/project/emulation/FixedPoint/BondingCurve.py
+++ b/project/emulation/FixedPoint/BondingCurve.py
@@ -3,7 +3,6 @@ from .common.Uint256 import *
 from . import AnalyticMath
 from . import IntegralMath
 
-MIN_WEIGHT = 1;
 MAX_WEIGHT = 1000000;
 
 '''


### PR DESCRIPTION
1. In function `deposit`, allow input `weights = 1`
2. In function `withdraw`, allow input `weights = 1`
3. In function `invest`, allow input `weights = 1`
4. In all functions, remove the special handling of `amount == 0`
5. In all functions, reorganize the `require` statements and improve their messages